### PR TITLE
Use the correct message for NIC input in jconstruct.

### DIFF
--- a/tools/jconstruct
+++ b/tools/jconstruct
@@ -83,7 +83,7 @@ get_jail_interface()
 	_default="${interface}"
 
 	while [ x${_input} = x ]; do
-		$ECHO "${BOLD}${ip4_addr_msg} e.g: ${GREEN}${_default}${NORMAL}"
+		$ECHO "${BOLD}${interface_msg} e.g: ${GREEN}${_default}${NORMAL}"
 		read _input
 		[ -z "${_input}" ] && _input="${_default}"
 	done


### PR DESCRIPTION
The correct message for NIC input in jconstruct should be used, not the IP address/mask message, as it is confusing.