### PR TITLE
Fix vm_profile name to match filename

### DIFF
--- a/etc/defaults/vm-linux-ubuntuserver-x86-14.04.conf
+++ b/etc/defaults/vm-linux-ubuntuserver-x86-14.04.conf
@@ -1,5 +1,5 @@
 # don't remove this line:
-vm_profile="ubuntuserver-x86-14.04.4"
+vm_profile="ubuntuserver-x86-14.04"
 
 # this is one-string additional info strings in dialogue menu
 long_description="Linux UbuntuServer LTS 14.04.4 x86-64 (64 bit) architecture"


### PR DESCRIPTION
vm_profile did not match the filename, causing Ubuntu 14.04 LTS bconstruct to fail with `No such profile: vm-linux-ubuntuserver-x86-14.04.4.conf`
